### PR TITLE
fix ci: wrong binary file path

### DIFF
--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -67,7 +67,7 @@ jobs:
       if: ${{ steps.tag.outputs.upload == 'true' }}
       run: |
         sudo mkdir -p /home/plugins
-        cd ./.tmp/bin/${{ matrix.go_arch }}
+        cd ./.tmp/bin
         tar -cvzf /home/plugins/spider-cni-plugins-linux-${{ matrix.go_arch }}-${{ inputs.ref }}.tar *
 
     - name: Upload Binary artifact


### PR DESCRIPTION
fix ci: wrong binary file path

Signed-off-by: cyclinder <qifeng.guo@daocloud.io>