### PR TITLE
fix wrong cni-package url when 'RUN_ON_LOCAL'=false

### DIFF
--- a/.github/workflows/ci-bot.yaml
+++ b/.github/workflows/ci-bot.yaml
@@ -21,9 +21,13 @@ env:
     cc
     label-kind
     label-bug
-    label-documentation
+    label-doc
     label-enhancement
     label-question
+    label-kind/bug
+    label-kind/doc
+    label-kind/feature
+    label-kind/cleanup
 
   # This plugins is for organization member or repository member
   MEMBERS_PLUGINS: |-
@@ -49,14 +53,16 @@ env:
 
   REVIEWERS: |-
     cyclinder
+    weizhoublue
   APPROVERS: |-
     cyclinder
+    weizhoublue
   MAINTAINERS: |-
     cyclinder
+    weizhoublue
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPOSITORY: ${{ github.repository }}
 jobs:
-
   issue_opened:
     name: Issue Opened
     if: ${{ github.event_name == 'issues' }}

--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: update apt-get sources_repo
         id: sources_repo
         run:
-          make -C test update-repo
+          make -C test update-repo IP_FAMILY=${{ inputs.ip_family }}
 
       - name: Run E2E
         id: e2e

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,9 +35,9 @@ install:
 	echo -e "  \033[35m Start install network-component: \033[0m" ; \
 	if [ ! -f ${E2E_KUBECONFIG} ]; then echo "can't found ${E2E_KUBECONFIG}, please provide the right kubeconfig path using env E2E_KUBECONFIG" && exit 1; fi ; \
 	export CLUSTER_POD_SUBNET_V4=${CLUSTER_POD_SUBNET_V4}; \
-    export CLUSTER_POD_SUBNET_V6=${CLUSTER_POD_SUBNET_V6}; \
-    export CLUSTER_SERVICE_SUBNET_V4=${CLUSTER_SERVICE_SUBNET_V4}; \
-    export CLUSTER_SERVICE_SUBNET_V6=${CLUSTER_SERVICE_SUBNET_V6}; \
+	export CLUSTER_POD_SUBNET_V6=${CLUSTER_POD_SUBNET_V6}; \
+	export CLUSTER_SERVICE_SUBNET_V4=${CLUSTER_SERVICE_SUBNET_V4}; \
+	export CLUSTER_SERVICE_SUBNET_V6=${CLUSTER_SERVICE_SUBNET_V6}; \
 	export CALICO_VERSION=${CALICO_VERSION}; \
 	export E2E_KUBECONFIG=${E2E_KUBECONFIG}; \
 	export IP_FAMILY=${IP_FAMILY} ; \

--- a/test/scripts/install/01-default-cni.sh
+++ b/test/scripts/install/01-default-cni.sh
@@ -25,6 +25,7 @@ else
   export CALICO_IMAGE_REPO=docker.io
 fi
 
+mkdir -p ${PROJECT_ROOT_PATH}/.tmp/config
 cp ${PROJECT_ROOT_PATH}/test/config/calico.yaml ${PROJECT_ROOT_PATH}/.tmp/config/calico.yaml
 
 # Install default-cni
@@ -47,21 +48,21 @@ case ${IP_FAMILY} in
       export CALICO_CNI_ASSIGN_IPV6=false
       export CALICO_IP_AUTODETECT=autodetect
       export CALICO_IP6_AUTODETECT=none
-      export FELIX_IPV6SUPPORT=false
+      export CALICO_FELIX_IPV6SUPPORT=false
     ;;
   ipv6)
       export CALICO_CNI_ASSIGN_IPV4=false
       export CALICO_CNI_ASSIGN_IPV6=true
-      export CALICO_IP_AUTODETECT=none
+      export CALICO_IP_AUTODETECT=autodetect
       export CALICO_IP6_AUTODETECT=autodetect
-      export FELIX_IPV6SUPPORT=true
+      export CALICO_FELIX_IPV6SUPPORT=true
     ;;
   dual)
       export CALICO_CNI_ASSIGN_IPV4=true
       export CALICO_CNI_ASSIGN_IPV6=true
       export CALICO_IP_AUTODETECT=autodetect
       export CALICO_IP6_AUTODETECT=autodetect
-      export FELIX_IPV6SUPPORT=true
+      export CALICO_FELIX_IPV6SUPPORT=true
     ;;
   *)
     echo "the value of IP_FAMILY: ipv4 or ipv6 or dual"
@@ -99,5 +100,8 @@ for CALICO_IMAGE in ${CALICO_IMAGE_LIST}; do
 done
 
 kubectl apply -f  ${PROJECT_ROOT_PATH}/.tmp/config/calico.yaml --kubeconfig ${E2E_KUBECONFIG}
+
 kubectl wait --for=condition=ready -l k8s-app=calico-node --timeout=${INSTALL_TIME_OUT} pod -n kube-system --kubeconfig ${E2E_KUBECONFIG}
+kubectl get po -n kube-system --kubeconfig ${E2E_KUBECONFIG}
+
 echo -e "\033[35m Succeed to install Calico \033[0m"

--- a/test/scripts/install/04-cni-plugins.sh
+++ b/test/scripts/install/04-cni-plugins.sh
@@ -19,7 +19,7 @@ DOWNLOAD_URL="https://github.com/containernetworking/plugins/releases/download/$
 if [ ${RUN_ON_LOCAL} == "true" ]; then DOWNLOAD_URL=https://ghproxy.com/${DOWNLOAD_URL} ; fi
 if [ ! -f  "${PROJECT_ROOT_PATH}/.tmp/plugins/${PACKAGE_NAME}" ]; then
   echo "begin to download cni-plugins ${PACKAGE_NAME} "
-  wget -P ${DOWNLOAD_DIR} https://ghproxy.com/https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/${PACKAGE_NAME}
+  wget -P ${DOWNLOAD_DIR} ${DOWNLOAD_URL}
 else
   echo "${DOWNLOAD_DIR}/${PACKAGE_NAME} exist, Skip download"
 fi

--- a/test/scripts/network-config.sh
+++ b/test/scripts/network-config.sh
@@ -53,8 +53,8 @@ if [ ${IP_FAMILY} == "ipv4" ]; then
     docker exec ${containerID} ip addr add 172.100.0.1/16 dev ${DEFAULT_INTERFACE}.${VLANID1}
     docker exec ${containerID} ip addr add 172.200.0.1/16 dev ${DEFAULT_INTERFACE}.${VLANID2}
 elif [ ${IP_FAMILY} == "ipv6" ]; then
-    docker exec ${containerID}  sysctl -w net.ipv6.conf.${DEFAULT_INTERFACE}/${VLANID1}.disable_ipv6
-    docker exec ${containerID}  sysctl -w net.ipv6.conf.${DEFAULT_INTERFACE}/${VLANID2}.disable_ipv6
+    docker exec ${containerID}  sysctl -w net.ipv6.conf.${DEFAULT_INTERFACE}/${VLANID1}.disable_ipv6=0
+    docker exec ${containerID}  sysctl -w net.ipv6.conf.${DEFAULT_INTERFACE}/${VLANID2}.disable_ipv6=0
     docker exec ${containerID} ip addr add fd00:172:100::1/64 dev ${DEFAULT_INTERFACE}.${VLANID1}
     docker exec ${containerID} ip addr add fd00:172:200::1/64 dev ${DEFAULT_INTERFACE}.${VLANID2}
 elif [ ${IP_FAMILY} == "dual" ]; then


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind doc
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

wrong cni-package URL leads to e2e failed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```