### PR TITLE
opt cmd del: skip call cmdDel when pod no ips

### DIFF
--- a/plugins/router/router.go
+++ b/plugins/router/router.go
@@ -238,16 +238,14 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	chainedInterfaceIps, err := utils.GetChainedInterfaceIps(netns, args.IfName, true, true)
 	if err != nil {
-		logger.Error(err.Error())
-		return err
+		logger.Warn("Pod No IPs, Skip call CmdDel", zap.Error(err))
+		return nil
 	}
 	logger.Debug("Get ChainedInterface IPs", zap.String("interface", args.IfName), zap.Strings("IPs", chainedInterfaceIps))
-
 	if err = utils.RuleDel(netns, logger, *conf.HostRuleTable, chainedInterfaceIps); err != nil {
 		logger.Error(err.Error())
 		return err
 	}
-
 	logger.Debug("Succeed to call CmdDel for Router-Plugin")
 	return err
 }

--- a/test/scripts/install/05-spiderdoctor.sh
+++ b/test/scripts/install/05-spiderdoctor.sh
@@ -28,6 +28,11 @@ case ${IP_FAMILY} in
     exit 1
 esac
 
+if [ ${RUN_ON_LOCAL} == true ]; then
+  SPIDERDOCTOR_HELM_OPTIONS+=" --set spiderdoctorAgent.image.registry=ghcr.m.daocloud.io \
+   --set spiderdoctorController.image.registry=ghcr.m.daocloud.io "
+fi
+
 echo "SPIDERDOCTOR_HELM_OPTIONS: ${SPIDERDOCTOR_HELM_OPTIONS}"
 
 helm repo add spiderdoctor https://spidernet-io.github.io/spiderdoctor


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

#### What this PR does / why we need it:

opt cmd del: skip call cmdDel when pod no ips

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
