### PR TITLE
found cali* or lxc* by using link.parentIndex without netlink.RouteGet

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -686,7 +686,12 @@ func RuleDel(netNS ns.NetNS, logger *zap.Logger, ruleTable int, ips []string) er
 }
 
 // AddStaticNeighTable fix the problem of communication failure between pods and hosts by adding neigh table on pod and host
-func AddStaticNeighTable(logger *zap.Logger, netns ns.NetNS, enableIpv4, enableIpv6 bool, defaultOverlayInterface string, chainedInterfaceIps []string) error {
+func AddStaticNeighTable(logger *zap.Logger, netns ns.NetNS, iSriov, enableIpv4, enableIpv6 bool, defaultOverlayInterface string, chainedInterfaceIps []string) error {
+	if iSriov {
+		logger.Info("Main-cni is sriov, don't need set chained route")
+		return nil
+	}
+
 	parentIndex := -1
 	defaultOverlayMac := ""
 	hostIPs, err := GetHostIps(logger, enableIpv4, enableIpv6)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -952,7 +952,11 @@ var _ = Describe("Utils", func() {
 	})
 	Context("test AddStaticNeighTable", func() {
 		It("success", func() {
-			err := AddStaticNeighTable(logger, testNetNs, true, true, conVethName, defaultInterfaceIPs)
+			err := AddStaticNeighTable(logger, testNetNs, false, true, true, conVethName, defaultInterfaceIPs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("skip", func() {
+			err := AddStaticNeighTable(logger, testNetNs, true, true, true, conVethName, defaultInterfaceIPs)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -960,7 +964,7 @@ var _ = Describe("Utils", func() {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 			patches.ApplyFuncReturn(GetHostIps, nil, errors.New("get host err"))
-			err := AddStaticNeighTable(logger, testNetNs, true, true, conVethName, defaultInterfaceIPs)
+			err := AddStaticNeighTable(logger, testNetNs, false, true, true, conVethName, defaultInterfaceIPs)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -968,7 +972,7 @@ var _ = Describe("Utils", func() {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 			patches.ApplyFuncReturn(netlink.LinkByName, nil, errors.New("linkByName err"))
-			err := AddStaticNeighTable(logger, testNetNs, true, true, conVethName, defaultInterfaceIPs)
+			err := AddStaticNeighTable(logger, testNetNs, false, true, true, conVethName, defaultInterfaceIPs)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -976,7 +980,7 @@ var _ = Describe("Utils", func() {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 			patches.ApplyFuncReturn(netlink.LinkByIndex, nil, errors.New("LinkByIndex err"))
-			err := AddStaticNeighTable(logger, testNetNs, true, true, conVethName, defaultInterfaceIPs)
+			err := AddStaticNeighTable(logger, testNetNs, false, true, true, conVethName, defaultInterfaceIPs)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -984,7 +988,7 @@ var _ = Describe("Utils", func() {
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 			patches.ApplyFuncReturn(net.ParseCIDR, nil, nil, errors.New("LinkByIndex err"))
-			err := AddStaticNeighTable(logger, testNetNs, true, true, conVethName, defaultInterfaceIPs)
+			err := AddStaticNeighTable(logger, testNetNs, false, true, true, conVethName, defaultInterfaceIPs)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

#### What this PR does / why we need it:

when default-cni is cilium, device of `ip r get <cilium_ip>` is cilium_host without  lxc*, so found cali* or lxc* by using link.parentIndex without netlink.RouteGet.

