### PR TITLE
support custom mac address

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	ty "github.com/spidernet-io/cni-plugins/pkg/types"
 	"k8s.io/utils/pointer"
 	"net"
+	"regexp"
 	"strings"
 )
 
@@ -82,4 +83,19 @@ func validateRoutes(routes []string) ([]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func ValidateOverwriteMacAddress(prefix string) error {
+	if prefix == "" {
+		return nil
+	}
+	// prefix format like: 00:00、0a:1b
+	matchRegexp, err := regexp.Compile("^" + "(" + "[a-fA-F0-9]{2}[:-][a-fA-F0-9]{2}" + ")" + "$")
+	if err != nil {
+		return err
+	}
+	if !matchRegexp.MatchString(prefix) {
+		return fmt.Errorf("mac_prefix format should be match regex: [a-fA-F0-9]{2}[:][a-fA-F0-9]{2}, like '0a:1b'")
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -131,4 +131,18 @@ var _ = Describe("config", func() {
 			Expect(got).To(Equal(want))
 		})
 	})
+	Context("Test ValidateOverwriteMacAddress", func() {
+		It("mac_options is empty", func() {
+			err := ValidateOverwriteMacAddress("")
+			Expect(err).To(BeNil())
+		})
+		It("prefix is invalid return err", func() {
+			err := ValidateOverwriteMacAddress("wrong mac")
+			Expect(err.Error()).To(Equal("mac_prefix format should be match regex: [a-fA-F0-9]{2}[:][a-fA-F0-9]{2}, like '0a:1b'"))
+		})
+		It("enable and prefix is valid", func() {
+			err := ValidateOverwriteMacAddress("0a:1b")
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -11,6 +11,8 @@ var DefaultInterfacesToExclude = []string{
 }
 
 var OverlayRouteTable = 100
+var DefaultInterfaceName = "eth0"
+var DefaultMacPrefix = "80:80"
 
 var ErrRouteFileExist string = "file exists"
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"net"
+	"net/netip"
 	"os"
 	"regexp"
 )
@@ -1039,6 +1040,47 @@ var _ = Describe("Utils", func() {
 			})
 			err := setRPFilter(logger, v)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("test convertIp2Mac", func() {
+		regex, err := regexp.Compile("^" + "[a-fA-F0-9]{2}" + "(" + ":[a-fA-F0-9]{2}" + ")" + "{3}" + "$")
+		Expect(err).To(BeNil())
+
+		It("test ipv4", func() {
+			addr, err := netip.ParseAddr("192.168.20.1")
+			Expect(err).To(BeNil())
+
+			macSufficx, err := inetAton(addr)
+			Expect(err).To(BeNil())
+
+			matched := regex.MatchString(macSufficx)
+			Expect(matched).To(BeTrue())
+		})
+
+		It("test ipv6", func() {
+			addr, err := netip.ParseAddr("fd00:110:120::1")
+			Expect(err).To(BeNil())
+
+			macSufficx, err := inetAton(addr)
+			Expect(err).To(BeNil())
+
+			matched := regex.MatchString(macSufficx)
+			Expect(matched).To(BeTrue())
+		})
+
+		It("invalid ip", func() {
+			_, err := inetAton(netip.Addr{})
+			Expect(err.Error()).To(Equal("invalid ip address"))
+		})
+	})
+
+	Context("Test OverwriteMacAddress", func() {
+
+		It("a right config and pass", func() {
+			newmac, err := OverwriteMacAddress(logger, testNetNs, "0a:1b", conVethName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newmac).NotTo(BeEmpty(), newmac)
 		})
 	})
 

--- a/plugins/router/README.md
+++ b/plugins/router/README.md
@@ -57,7 +57,8 @@ spec:
                 "log_options": {
                   "log_level": "debug",
                   "log_file": "/var/log/meta-plugins/router.log"
-                }
+                },
+                "mac_prefix": "0a:0b"
             }
         ]
     }
@@ -73,3 +74,4 @@ spec:
 - `skip_call`: 是否跳过调用此插件，默认为false。
 - `log_options`: 日志配置。
 - `rp_filter`: 设置主机 rp_filter 参数, value 取值范围为 `0,1,2`
+- `mac_prefix`: 表示是否固定 Mac 地址的统一前缀, 为 4 个 16进制数, 配置格式为: "0a:1b", 需要满足 Mac 地址要求。如果`mac_prefix`为空, 表示不启用该功能(默认)。

--- a/plugins/veth/README.md
+++ b/plugins/veth/README.md
@@ -57,7 +57,8 @@ spec:
                 "log_options": {
                   "log_level": "debug",
                   "log_file": "/var/log/meta-plugins/veth.log"
-                }
+                },
+                "mac_prefix": "0a:0b"
             }
         ]
     }
@@ -71,3 +72,4 @@ spec:
 - `skip_call`: 是否跳过调用此插件，默认为false。
 - `log_options`: 日志配置。
 - `rp_filter`: 设置主机 rp_filter 参数, value 取值范围为 `0,1,2`
+- `mac_prefix`: 表示是否固定 Mac 地址的统一前缀, 为 4 个 16进制数, 配置格式为: "0a:1b", 需要满足 Mac 地址要求。如果`mac_prefix`为空, 表示不启用该功能(默认)。

--- a/test/scripts/install/02-multus-underlay.sh
+++ b/test/scripts/install/02-multus-underlay.sh
@@ -138,7 +138,8 @@ spec:
                     "value": 2
                 },
                 "overlay_interface": "eth0",
-                "skip_call": false
+                "skip_call": false,
+                "mac_prefix": "0a:0b"
             }
         ]
     }
@@ -181,7 +182,8 @@ spec:
                     "value": 2
                 },
                 "overlay_interface": "eth0",
-                "skip_call": false
+                "skip_call": false,
+                "mac_prefix": "0a:0b"
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

#### What this PR does / why we need it:

support custom mac address

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/spidernet-io/cni-plugins/issues/148

#### Special notes for your reviewer:

enable this feature with cni_config, for example:
```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: macvlan-vlan0-overlay
  namespace: kube-system
spec:
  config: |-
    {
        "cniVersion": "0.3.1",
        "name": "macvlan-overlay",
        "plugins": [
            {
                "type": "macvlan",
                "master": "enp4s0f0np0",
                "mode": "bridge",
                "ipam": {
                    "type": "spiderpool",
                    "log_level": "DEBUG",
                    "log_file_path": "/var/log/spidernet/spiderpool.log",
                    "log_file_max_size": 100,
                    "log_file_max_age": 30,
                    "log_file_max_count": 10
                }
            },{
                "type": "router",
                "overlay_interface": "eth0",
                "migrate_route": -1, 
                "skip_call": false,
                "service_hijack_subnet": ["172.96.0.0/18","2001:4860:fd00::/108"],
                "overlay_hijack_subnet": ["10.240.0.0/12","fd00:10:244::/96"],
                "additional_hijack_subnet": [],
                "rp_filter": {
                    "set_host": true,
                    "value": 0
                },
                "log_options": {
                  "log_level": "debug",
                  "log_file": "/var/log/meta-plugins/router.log"
                },
                "mac_options": {
                  "mac_overwrite": true,
                  "mac_prefix": "0a:0b"
                }
            }
        ]
    }
```

by default, this feature is disabled.

